### PR TITLE
the example would not execute due to overwrite

### DIFF
--- a/README
+++ b/README
@@ -89,10 +89,10 @@ DESCRIPTION
     from modio import modio
     
     # BUS Number is the bus you found during setup, see instructions above!
-    modio = modio.Device(bus=1)
+    modioDev = modio.Device(bus=1)
     
     # Take control of the first relay (number 1 on board)
-    relay = modio.Relay(modio, 0)
+    relay = modio.Relay(modioDev, 0)
     
     # Turn it on!
     relay.CloseContact()


### PR DESCRIPTION
(on a side note, the relay.Get always returns off
