### PR TITLE
Relay close instead of open

### DIFF
--- a/modio.py
+++ b/modio.py
@@ -496,7 +496,7 @@ def HandleRelay(args):
   relay = args[1]
   board = Device()
   try:
-    if status == "open":
+    if status == "close":
       board.CloseContactRelay(int(relay))
     else:
       board.OpenContactRelay(int(relay))


### PR DESCRIPTION
The command line tool suggests to type in "open" to close a relay and vice versa.
